### PR TITLE
CircleCI artifacts: screenshot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'capybara-screenshot_config'
   gem 'codeclimate-test-reporter', require: false
   gem 'factory_girl_rails'
   gem 'guard-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,8 +62,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-screenshot_config (0.1.0)
-      capybara (~> 2.5)
     cliver (0.3.2)
     codeclimate-test-reporter (0.5.2)
       simplecov (>= 0.7.1, < 1.0.0)
@@ -265,7 +263,6 @@ DEPENDENCIES
   bullet
   byebug
   capybara
-  capybara-screenshot_config
   codeclimate-test-reporter
   coffee-rails
   factory_girl_rails

--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ machine:
 general:
   artifacts:
     - coverage
-    - screenshot
+    - tmp/capybara

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,10 +16,6 @@ require 'rspec/rails'
 
 require "capybara/poltergeist"
 Capybara.javascript_driver = :poltergeist
-Capybara::ScreenshotConfig.configure do |config|
-  # config.save_dir = "screenshot"
-  config.full = true
-end
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
As of capybara 2.7.0, capybara screenshot directory is changed to `/tmp/capybara`. 
https://github.com/jnicklas/capybara/commit/75084c59fc64bc2d43f54e09fcd97945755a81cf

So, I changed CircleCI artifacts path.

![screenshot](https://cloud.githubusercontent.com/assets/803398/16362885/1706324c-3bf5-11e6-9297-3a097ff06ba9.png)
